### PR TITLE
remove unhandled import arguments

### DIFF
--- a/lib/AnyEvent/SerialPort.pm
+++ b/lib/AnyEvent/SerialPort.pm
@@ -9,7 +9,7 @@ use constant {
 };
 
 use Carp qw/croak carp/;
-use Device::SerialPort qw/:PARAM :STAT 0.07/;
+use Device::SerialPort;
 use Fcntl;
 use Symbol qw(gensym);
 


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use lines when the import method does not exist.